### PR TITLE
#first aside: change "width: 100vw" to "right: 0"

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -44,10 +44,10 @@ body {
   }
 
   aside {
-    width: 100vw;
     position: absolute;
     bottom: 0;
     left: 0;
+    right: 0;
     text-align: center;
     overflow: hidden;
 


### PR DESCRIPTION
This prevents the `aside` element from extending beyond the width of the viewport and the ability to horizontally scroll will be removed
